### PR TITLE
Fix build-server command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev-server": "NODE_ENV=development nodemon -e ts server --exec ts-node",
     "dev-webpack": "webpack --mode development --watch --progress",
     "build": "yarn build-webpack && yarn build-server",
-    "build-server": "tsc --project tsconfig.server.json && cp -r ./server/views/ ./dist/views",
+    "build-server": "tsc --project tsconfig.server.json && cp -r ./server/views/ ./dist/",
     "build-webpack": "webpack --mode production --config=webpack.prod.config.js",
     "lint": "tslint 'client/**/*.@(ts|tsx)'",
     "format": "prettier --write 'client/**/*.@(ts|tsx)'",


### PR DESCRIPTION
Current command installs files to the wrong dir (`./dist/views/views/`)
```
root@ap-tps-erxes:/opt/erxes.io/erxes-widgets# cp -vvv -r ./server/views/ ./dist/views/
'./server/views/widget-test.ejs' -> './dist/views/views/widget-test.ejs'
'./server/views/widget.ejs' -> './dist/views/views/widget.ejs'
```

```
root@ap-tps-erxes:/opt/erxes.io/erxes-widgets# cp -vvv -r ./server/views/ ./dist/      
'./server/views/widget-test.ejs' -> './dist/views/widget-test.ejs'
'./server/views/widget.ejs' -> './dist/views/widget.ejs'
```